### PR TITLE
added margin to bottom of search results container

### DIFF
--- a/client/src/components/search/search-page.css
+++ b/client/src/components/search/search-page.css
@@ -64,6 +64,7 @@
     width: 96%;
     margin-left: 2%;
     margin-right: 2%;
+    margin-bottom: 1%;
     display: table;
     font-size: 20px;
     border: 1px solid rgb(33, 157, 247);


### PR DESCRIPTION
- added margin to the bottom of the search container so it isn't right up against the bottom of the window in landscape mode on mobile