### PR TITLE
Group modal closes when clicked outside

### DIFF
--- a/client/src/components/general/group-modal.css
+++ b/client/src/components/general/group-modal.css
@@ -19,8 +19,10 @@
     padding: 25px;
     position: relative;
     width: 40%;
+    max-height: 80vh;
     z-index: 1;
     font-size: 16px;
+    overflow: scroll;
 }
 
 

--- a/client/src/components/general/group-modal.js
+++ b/client/src/components/general/group-modal.js
@@ -122,13 +122,11 @@ class GroupModal extends Component{
             return (
                 <Fragment>
                     {children}
-                    <div id="group-modal" className="basic-modal">
+                    <div id="group-modal" className="basic-modal" onClick={this.close}>
                         <div onClick={e => e.stopPropagation()} className="basic-modal-content">
-                            <Link to="/search-group">
                                 <div className="group-modal-close" onClick={this.close}>
                                     x
                                 </div>
-                            </Link>
                             <div className="group-modal-details">
                                 {GroupData }
                             </div>

--- a/client/src/components/search/search-input.js
+++ b/client/src/components/search/search-input.js
@@ -2,6 +2,6 @@ import React from 'react'
 
 export default ({ props, resetFilter, input, className, label, meta: size, type = 'text' }) => (
    <div>
-      <input {...input} type={type} placeholder={label} size={size} className={className}/> <button className="search-filter-button" type="submit">FILTER</button> <button className="reset-search-button" onClick={resetFilter} type="button">RESET</button>
+      <input {...input} type={type} placeholder={label} size={size} className={className}/> <button className="search-filter-button" type="submit">SEARCH</button> <button className="reset-search-button" onClick={resetFilter} type="button">RESET</button>
    </div>
 )

--- a/client/src/components/search/search-page.css
+++ b/client/src/components/search/search-page.css
@@ -185,15 +185,23 @@
         white-space: nowrap;
         max-width: 75px;
     }
+
+    .search-filter-container {
+        margin: 1%;
+    }
 }
 
 @media only screen and (max-width: 330px){
+    .search-field {
+        width: 59%;
+    }
+
     .search-filter-button {
-        font-size: 16px;
+        font-size: 15px;
     }
     
     .reset-search-button {
-        font-size: 16px;
+        font-size: 15px;
     }
 }
 


### PR DESCRIPTION
- group modal closes when you click outside it again!
- added scroll to modal on landscape mode (need to test on live)
- added some margin to search/reset container on search page on smaller screen sizes so it isn't right up against the edge of the screen